### PR TITLE
try singleton pattern for unpackaged

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -85,10 +85,7 @@ Context::Context(Timer* ti, Recorder* rec)
       trans_id_(0),
       si_(0) {
         rng_ = new RandomNumberGenerator();
-        if (packages_.count("unpackaged") == 0) {
-          packages_["unpackaged"] = Package::CreateUnpackaged();
-        }
-}
+      }
 
 Context::~Context() {
   if (solver_ != NULL) {
@@ -207,6 +204,9 @@ Package::Ptr Context::AddPackage(std::string name, double fill_min, double fill_
 }
 
 Package::Ptr Context::GetPackageByName(std::string name) {
+  if (name == Package::unpackaged_name()) {
+    return Package::unpackaged();
+  }
   if (packages_.count(name) == 0) {
     throw KeyError("Invalid package name " + name);
   }
@@ -214,6 +214,9 @@ Package::Ptr Context::GetPackageByName(std::string name) {
 }
 
 Package::Ptr Context::GetPackageById(int id) {
+  if (id == Package::unpackaged_id()) {
+    return Package::unpackaged();
+  }
   if (id < 0) {
     throw ValueError("Invalid package id " + std::to_string(id));
   }

--- a/src/package.cc
+++ b/src/package.cc
@@ -24,8 +24,7 @@ Package::Ptr Package::Create(std::string name, double fill_min, double fill_max,
 Package::Ptr& Package::unpackaged() {
 
   if (!unpackaged_) {
-    Ptr p(new Package(unpackaged_name_));
-    unpackaged_ = p;
+    unpackaged_ = Ptr(new Package(unpackaged_name_));
   }
 
   return unpackaged_;

--- a/src/package.cc
+++ b/src/package.cc
@@ -5,6 +5,7 @@ namespace cyclus {
 
 // unpackaged id is 1, so start the user-declared packaging id at 2
 int Package::next_package_id_ = 2;
+Package::Ptr Package::unpackaged_ = NULL;
 
 Package::Ptr Package::Create(std::string name, double fill_min, double fill_max, std::string strategy) {
   if (fill_min < 0 || fill_max < 0) {
@@ -20,10 +21,11 @@ Package::Ptr Package::Create(std::string name, double fill_min, double fill_max,
 // singleton pattern: 
 // if the static member is not yet set, create a new object
 // otherwise return the object that already exists
-Package::Ptr& unpackaged() {
+Package::Ptr& Package::unpackaged() {
 
-  if !unpackaged_ {
-    unpackaged_ = new Package(unpackaged_name_);
+  if (!unpackaged_) {
+    Ptr p(new Package(unpackaged_name_));
+    unpackaged_ = p;
   }
 
   return unpackaged_;
@@ -56,11 +58,11 @@ Package::Package(std::string name, double fill_min, double fill_max, std::string
   name_(name), fill_min_(fill_min), fill_max_(fill_max), strategy_(strategy) {
     if (name == unpackaged_name_) {
       if (unpackaged_) {
-        throw ValueError("can't create a package with name " + unpackaged_name_);
+        throw ValueError("can't create a new package with name 'unpackaged'");
       }
       id_ = unpackaged_id_;
     } else {
-      id = next_package_id_++;
+      id_ = next_package_id_++;
     }
   }
 

--- a/src/package.cc
+++ b/src/package.cc
@@ -17,9 +17,16 @@ Package::Ptr Package::Create(std::string name, double fill_min, double fill_max,
   return p;
 }
 
-Package::Ptr Package::CreateUnpackaged() {
-  Ptr p(new Package(unpackaged_id_, unpackaged_name_));
-  return p;
+// singleton pattern: 
+// if the static member is not yet set, create a new object
+// otherwise return the object that already exists
+Package::Ptr unpackaged() {
+
+  if !unpackaged_ {
+    unpackaged_ = new Package(unpackaged_name_);
+  }
+
+  return unpackaged_;
 }
 
 double Package::GetFillMass(double qty) {
@@ -45,12 +52,16 @@ double Package::GetFillMass(double qty) {
   return fill_mass;
 }
   
-Package::Package() : id_(next_package_id_++), fill_min_(0), fill_max_(std::numeric_limits<double>::max()) {
-  name_ = "unnamed";
-}
-
-Package::Package(std::string name, double fill_min, double fill_max, std::string strategy) : name_(name), id_(next_package_id_++), fill_min_(fill_min), fill_max_(fill_max), strategy_(strategy) {}
-
-Package::Package(int id, std::string name) : id_(id), name_(name), fill_min_(0), fill_max_(std::numeric_limits<double>::max()) {}
+Package::Package(std::string name, double fill_min, double fill_max, std::string strategy) : 
+  name_(name), fill_min_(fill_min), fill_max_(fill_max), strategy_(strategy) {
+    if (name == unpackaged_name_) {
+      if (unpackaged_) {
+        throw ValueError("can't create a package with name " + unpackaged_name_);
+      }
+      id_ = unpackaged_id_;
+    } else {
+      id = next_package_id_++;
+    }
+  }
 
 } // namespace cyclus

--- a/src/package.cc
+++ b/src/package.cc
@@ -20,7 +20,7 @@ Package::Ptr Package::Create(std::string name, double fill_min, double fill_max,
 // singleton pattern: 
 // if the static member is not yet set, create a new object
 // otherwise return the object that already exists
-Package::Ptr unpackaged() {
+Package::Ptr& unpackaged() {
 
   if !unpackaged_ {
     unpackaged_ = new Package(unpackaged_name_);

--- a/src/package.h
+++ b/src/package.h
@@ -64,8 +64,8 @@ class Package {
             std::string strategy = "first");
 
     static const int unpackaged_id_ = 1;
-    static const char unpackaged_name_[11] = "unpackaged";
-    static Package* unpackaged_ = NULL;
+    static constexpr char unpackaged_name_[11] = "unpackaged";
+    static Ptr unpackaged_;
     static int next_package_id_;
 
     std::string name_;

--- a/src/package.h
+++ b/src/package.h
@@ -49,10 +49,10 @@ class Package {
     std::string strategy() const { return strategy_; }
 
     // returns the unpackaged id (1)
-    static int unpackaged_id() { return unpackaged_id_; }
+    static int unpackaged_id() const { return unpackaged_id_; }
 
     // returns the unpackaged package name
-    static std::string unpackaged_name() { return unpackaged_name_; }
+    static std::string unpackaged_name() const { return unpackaged_name_; }
 
     // returns the unpackaged singleton object
     static Ptr unpackaged();

--- a/src/package.h
+++ b/src/package.h
@@ -54,16 +54,18 @@ class Package {
     // returns the unpackaged package name
     static std::string unpackaged_name() { return unpackaged_name_; }
 
-  protected:
-    Package();
-    Package(std::string name, double fill_min, double fill_max, std::string strategy);
-    // creates the unpackaged type. Id is always 1.
-    static Package::Ptr CreateUnpackaged();
-    Package(int id, std::string name);
+    // returns the unpackaged singleton object
+    static Ptr unpackaged();
 
   private:
+    Package(std::string name, 
+            double fill_min = 0, 
+            double fill_max = std::numeric_limits<double>::max(), 
+            std::string strategy = "first");
+
     static const int unpackaged_id_ = 1;
-    static const std::string unpackaged_name_ = "unpackaged";
+    static const char* unpackaged_name_ = "unpackaged";
+    static Ptr unpackaged_ = NULL;
     static int next_package_id_;
 
     std::string name_;

--- a/src/package.h
+++ b/src/package.h
@@ -65,7 +65,7 @@ class Package {
 
     static const int unpackaged_id_ = 1;
     static const char* unpackaged_name_ = "unpackaged";
-    static Ptr unpackaged_ = NULL;
+    static Ptr& unpackaged_ = NULL;
     static int next_package_id_;
 
     std::string name_;

--- a/src/package.h
+++ b/src/package.h
@@ -49,10 +49,10 @@ class Package {
     std::string strategy() const { return strategy_; }
 
     // returns the unpackaged id (1)
-    static int unpackaged_id() const { return unpackaged_id_; }
+    static int unpackaged_id() { return unpackaged_id_; }
 
     // returns the unpackaged package name
-    static std::string unpackaged_name() const { return unpackaged_name_; }
+    static std::string unpackaged_name() { return unpackaged_name_; }
 
     // returns the unpackaged singleton object
     static Ptr& unpackaged();

--- a/src/package.h
+++ b/src/package.h
@@ -64,8 +64,8 @@ class Package {
             std::string strategy = "first");
 
     static const int unpackaged_id_ = 1;
-    static const char* unpackaged_name_ = "unpackaged";
-    static Ptr unpackaged_ = NULL;
+    static const char unpackaged_name_[11] = "unpackaged";
+    static Package* unpackaged_ = NULL;
     static int next_package_id_;
 
     std::string name_;

--- a/src/package.h
+++ b/src/package.h
@@ -55,7 +55,7 @@ class Package {
     static std::string unpackaged_name() const { return unpackaged_name_; }
 
     // returns the unpackaged singleton object
-    static Ptr unpackaged();
+    static Ptr& unpackaged();
 
   private:
     Package(std::string name, 
@@ -65,7 +65,7 @@ class Package {
 
     static const int unpackaged_id_ = 1;
     static const char* unpackaged_name_ = "unpackaged";
-    static Ptr& unpackaged_ = NULL;
+    static Ptr unpackaged_ = NULL;
     static int next_package_id_;
 
     std::string name_;


### PR DESCRIPTION
Here's a proposal for a more streamlined way to get a single unpackaged type for each simulation available across all contexts.

I'll add some comments inline.

I haven't tested it all yet.